### PR TITLE
removed unnecessary assignment to 'value'

### DIFF
--- a/lib/gauguin/palette_serializer.rb
+++ b/lib/gauguin/palette_serializer.rb
@@ -9,7 +9,7 @@ module Gauguin
       value = value.to_a.map do |color_key, group|
         [Gauguin::Color.from_a(color_key), group]
       end
-      value = Hash[value]
+      Hash[value]
     end
 
     def self.dump(value)


### PR DESCRIPTION
I noticed that the variable assignment to value is not needed since the last computation is automatically returned.